### PR TITLE
Expose supported ApplePay networks and button styling

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.4"
+    version: "2.0.5"
   path:
     dependency: transitive
     description:

--- a/lib/src/models/apple_pay_config.dart
+++ b/lib/src/models/apple_pay_config.dart
@@ -9,6 +9,18 @@ class ApplePayConfig {
   /// An option to enable the manual auth and capture
   bool manual;
 
+  List<String> merchantCapabilities;
+
+  List<String> supportedNetworks;
+
   ApplePayConfig(
-      {required this.merchantId, required this.label, required this.manual});
+      {required this.merchantId,
+      required this.label,
+      required this.manual,
+      this.merchantCapabilities = const ["3DS", "debit", "credit"],
+      this.supportedNetworks = const ["amex", "visa", "mada", "masterCard"]})
+      : assert(merchantCapabilities.contains("3DS"),
+            "Merchant Capabilities must contain 3DS"),
+        assert(supportedNetworks.isNotEmpty,
+            'at least 1 network must be supported');
 }

--- a/lib/src/widgets/apple_pay.dart
+++ b/lib/src/widgets/apple_pay.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pay/pay.dart';
 import 'package:moyasar/moyasar.dart';
+import 'dart:convert';
 
 /// The widget that shows the Apple Pay button.
 class ApplePay extends StatelessWidget {
@@ -38,8 +39,8 @@ class ApplePay extends StatelessWidget {
         "data": {
           "merchantIdentifier": "${config.applePay?.merchantId}",
           "displayName": "${config.applePay?.label}",
-          "merchantCapabilities": ["3DS", "debit", "credit"],
-          "supportedNetworks": ["amex", "visa", "mada", "masterCard"],
+          "merchantCapabilities": ${jsonEncode(config.applePay?.merchantCapabilities)},
+          "supportedNetworks": ${jsonEncode(config.applePay?.supportedNetworks)},
           "countryCode": "SA",
           "currencyCode": "SAR"
         }

--- a/lib/src/widgets/apple_pay.dart
+++ b/lib/src/widgets/apple_pay.dart
@@ -5,12 +5,19 @@ import 'dart:convert';
 
 /// The widget that shows the Apple Pay button.
 class ApplePay extends StatelessWidget {
-  ApplePay({super.key, required this.config, required this.onPaymentResult})
+  ApplePay(
+      {super.key,
+      required this.config,
+      required this.onPaymentResult,
+      this.buttonType = ApplePayButtonType.inStore,
+      this.buttonStyle = ApplePayButtonStyle.black})
       : assert(config.applePay != null,
             "Please add applePayConfig when instantiating the paymentConfig.");
 
   final PaymentConfig config;
   final Function onPaymentResult;
+  final ApplePayButtonType buttonType;
+  final ApplePayButtonStyle buttonStyle;
 
   void onApplePayError(error) {
     onPaymentResult(PaymentCanceledError());
@@ -58,7 +65,8 @@ class ApplePay extends StatelessWidget {
           amount: (config.amount / 100).toStringAsFixed(2),
         )
       ],
-      type: ApplePayButtonType.inStore,
+      type: buttonType,
+      style: buttonStyle,
       onPaymentResult: onApplePayResult,
       width: MediaQuery.of(context).size.width,
       height: 40,


### PR DESCRIPTION
Hello Moyassar's team 👋 

the is a small change on ApplePay and ApplePayConfig to enable SDK users to have a finer control over the supported networks and button styling.

All of the new parameters are optional and will default to the previous hardcoded values so that no breaking changes are introduced.