### PR TITLE
add callback for initiated PaymentStatus

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -39,10 +39,20 @@ class _CoffeeShopState extends State<CoffeeShop> {
           label: 'Blue Coffee Beans',
           manual: false));
 
-  void onPaymentResult(result) {
+  Future<void> onPaymentResult(result) async {
     if (result is PaymentResponse) {
       showToast(context, result.status.name);
       switch (result.status) {
+        case PaymentStatus.initiated:
+          // handle initiated.
+          // register the payment id on the server in the user payments data
+          await Future.delayed(
+            Durations.medium2,
+            () {
+              print("initiated payment with Id: ${result.id}");
+            },
+          );
+          break;
         case PaymentStatus.paid:
           // handle success.
           break;

--- a/example/lib/widgets/payment.dart
+++ b/example/lib/widgets/payment.dart
@@ -3,7 +3,7 @@ import 'package:moyasar/moyasar.dart';
 
 class PaymentMethods extends StatelessWidget {
   final PaymentConfig paymentConfig;
-  final Function onPaymentResult;
+  final Function(dynamic) onPaymentResult;
 
   const PaymentMethods(
       {super.key, required this.paymentConfig, required this.onPaymentResult});

--- a/lib/src/widgets/credit_card.dart
+++ b/lib/src/widgets/credit_card.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:moyasar/moyasar.dart';
@@ -14,7 +16,7 @@ class CreditCard extends StatefulWidget {
       required this.onPaymentResult,
       this.locale = const Localization.en()});
 
-  final Function onPaymentResult;
+  final FutureOr<void> Function(dynamic) onPaymentResult;
   final PaymentConfig config;
   final Localization locale;
 
@@ -76,6 +78,12 @@ class _CreditCardState extends State<CreditCard> {
       widget.onPaymentResult(result);
       return;
     }
+
+    /// return the initiated status with the payment id
+    /// wait the [onPaymentResult] to complete to make sure that
+    /// the app register this payment on the backend before continue.
+    /// if [onPaymentResult] has any exception this will stop open [ThreeDSWebView]
+    await widget.onPaymentResult(result);
 
     final String transactionUrl =
         (result.source as CardPaymentResponseSource).transactionUrl;

--- a/test/widgets/credit_card_test.dart
+++ b/test/widgets/credit_card_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:moyasar/moyasar.dart';
@@ -12,7 +14,7 @@ Widget createTestableApp(
       description: "Coffee",
       creditCard: CreditCardConfig(saveCard: tokenizeCard, manual: manual));
 
-  void onPaymentResult() {}
+  FutureOr<void> onPaymentResult(dynamic) {}
 
   return MaterialApp(
       home: Scaffold(


### PR DESCRIPTION
on the web there are option to add callback function before open 3DS, to make the app able to register the transaction id on the server with the user data.

[https://docs.moyasar.com/credit-card](https://docs.moyasar.com/credit-card)

```
Option 2: Callback Function

The other option is to provide a callback function, and due to the asynchronous nature of JavaScript, 
you need to return a Promise object which lets the form wait until your task is completed.
```


this pull request add the same functionality on the flutter sdk.

