### PR TITLE
Add toJson() method to the response models.

### DIFF
--- a/lib/src/models/payment_response.dart
+++ b/lib/src/models/payment_response.dart
@@ -60,6 +60,43 @@ class PaymentResponse {
       source = json['source'];
     }
   }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['id'] = id;
+    data['status'] = status.name;
+    data['amount'] = amount;
+    data['fee'] = fee;
+    data['currency'] = currency;
+    data['refunded'] = refunded;
+    data['refunded_at'] = refundedAt;
+    data['captured'] = captured;
+    data['captured_at'] = capturedAt;
+    data['voided_at'] = voidedAt;
+    data['description'] = description;
+    data['amount_format'] = amountFormat;
+    data['fee_format'] = feeFormat;
+    data['refunded_format'] = refundedFormat;
+    data['captured_format'] = capturedFormat;
+    data['invoice_id'] = invoiceId;
+    data['ip'] = ip;
+    data['callback_url'] = callbackUrl;
+    data['created_at'] = createdAt;
+    data['updated_at'] = updatedAt;
+    if (metadata != null) {
+      data['metadata'] = metadata;
+    }
+    if (source != null) {
+      if (source is CardPaymentResponseSource) {
+        data['source'] = (source as CardPaymentResponseSource).toJson();
+      } else if (source is ApplePayPaymentResponseSource) {
+        data['source'] = (source as ApplePayPaymentResponseSource).toJson();
+      } else {
+        data['source'] = source;
+      }
+    }
+    return data;
+  }
 }
 
 enum PaymentStatus { initiated, paid, failed, authorized, captured }

--- a/lib/src/models/sources/apple_pay/apple_pay_response_source.dart
+++ b/lib/src/models/sources/apple_pay/apple_pay_response_source.dart
@@ -26,4 +26,14 @@ class ApplePayPaymentResponseSource implements PaymentResponseSource {
         gatewayId = json['gateway_id'],
         referenceNumber = json['reference_number'],
         message = json['message'];
+
+  Map<String, dynamic> toJson() {
+    return {
+      'type': type.toString().split('.').last,
+      'number': number,
+      'gateway_id': gatewayId,
+      'reference_number': referenceNumber,
+      'message': message,
+    };
+  }
 }

--- a/lib/src/models/sources/card/card_response_source.dart
+++ b/lib/src/models/sources/card/card_response_source.dart
@@ -42,4 +42,17 @@ class CardPaymentResponseSource implements PaymentResponseSource {
         token = json['token'],
         message = json['message'],
         transactionUrl = json['transaction_url'];
+
+  Map<String, dynamic> toJson() {
+    return {
+      'company': company.name,
+      'name': name,
+      'number': number,
+      'gateway_id': gatewayId,
+      'reference_number': referenceNumber,
+      'token': token,
+      'message': message,
+      'transaction_url': transactionUrl,
+    };
+  }
 }


### PR DESCRIPTION
This commit adds `.toJson()` method to the models that are created from JSON responses:

- PaymentResponse
- CardPaymentResponseSource
- ApplePayPaymentResponseSource

This is very useful for developers who need to store the raw JSON response into their own database.