### PR TITLE
adding a theme InheritedWidget that toggles credit card and stc pay screens as the app Ui (dark , light)

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -23,8 +23,8 @@ if (flutterVersionName == null) {
 }
 
 android {
-    compileSdkVersion 34
-    ndkVersion flutter.ndkVersion
+    compileSdkVersion 35
+    ndkVersion "27.0.12077973"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -45,7 +45,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
         minSdkVersion 21
-        targetSdkVersion flutter.targetSdkVersion
+        targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Oct 15 20:44:26 EDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,8 @@
+import 'package:coffee_flutter/theme/app_theme.dart';
 import 'package:coffee_flutter/widgets/payment.dart';
 import 'package:flutter/material.dart';
 import 'package:moyasar/moyasar.dart';
+import 'package:moyasar/theme/moyasar_theme.dart';
 
 import 'widgets/coffee.dart';
 
@@ -13,9 +15,12 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
+      theme: AppTheme.lightTheme,
+      darkTheme: AppTheme.darkTheme,
+      themeMode: ThemeMode.dark,
       debugShowCheckedModeBanner: false,
-      home: CoffeeShop(),
+      home: const CoffeeShop(),
     );
   }
 }
@@ -88,7 +93,6 @@ class _CoffeeShopState extends State<CoffeeShop> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        backgroundColor: Colors.white,
         resizeToAvoidBottomInset: true,
         body: Center(
           child: SizedBox(
@@ -96,9 +100,12 @@ class _CoffeeShopState extends State<CoffeeShop> {
             child: ListView(
               children: [
                 const CoffeeImage(),
-                PaymentMethods(
-                  paymentConfig: paymentConfig,
-                  onPaymentResult: onPaymentResult,
+                MoyasarTheme(
+                  data: AppTheme.darkTheme,
+                  child: PaymentMethods(
+                    paymentConfig: paymentConfig,
+                    onPaymentResult: onPaymentResult,
+                  ),
                 ),
               ],
             ),

--- a/example/lib/theme/app_theme.dart
+++ b/example/lib/theme/app_theme.dart
@@ -1,0 +1,92 @@
+// lib/core/themes/app_theme.dart
+
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  const AppTheme._();
+
+  static final lightTheme = ThemeData(
+    brightness: Brightness.light,
+    primaryColor: kBackgroundColor,
+    visualDensity: VisualDensity.adaptivePlatformDensity,
+    scaffoldBackgroundColor: kBackgroundColor,
+    appBarTheme: AppBarTheme(
+      backgroundColor: kBackgroundColor,
+      foregroundColor: kLightTextColor,
+    ),
+    textButtonTheme: TextButtonThemeData(
+      style: TextButton.styleFrom(foregroundColor: kLightSecondaryColor),
+    ),
+    elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ButtonStyle(
+            backgroundColor: WidgetStatePropertyAll(kBackgroundColor),
+            foregroundColor: WidgetStatePropertyAll(kLightPrimaryColor))),
+    inputDecorationTheme: InputDecorationTheme(
+      fillColor: kBackgroundColor,
+      filled: true,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8.0),
+        borderSide: BorderSide(color: Colors.black54, width: 3.0),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(4.0),
+        borderSide: BorderSide(color: kLightTextColor),
+      ),
+    ),
+    fontFamily: 'ElMessiri',
+    colorScheme: ColorScheme.light(
+        primary: kLightParticlesColor,
+        secondary: kLightSecondaryColor,
+        surface: kBackgroundColor,
+        onPrimary: kLightPrimaryColor),
+  );
+
+  static final darkTheme = ThemeData(
+    brightness: Brightness.dark,
+    primaryColor: kDarkPrimaryColor,
+    visualDensity: VisualDensity.adaptivePlatformDensity,
+    scaffoldBackgroundColor: kDarkBackgroundColor,
+    appBarTheme: AppBarTheme(
+      backgroundColor: kDarkBackgroundColor,
+      foregroundColor: kDarkTextColor,
+    ),
+    textButtonTheme: TextButtonThemeData(
+      style: TextButton.styleFrom(foregroundColor: kDarkTextColor),
+    ),
+    elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ButtonStyle(
+            backgroundColor: WidgetStatePropertyAll(kDarkAccentColor),
+            foregroundColor: WidgetStatePropertyAll(kDarkTextColor))),
+    inputDecorationTheme: InputDecorationTheme(
+        fillColor: kDarkBackgroundColor,
+        filled: true,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8.0),
+          borderSide: const BorderSide(color: Colors.white30, width: 1.0),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(4.0),
+          borderSide: BorderSide(color: kDarkAccentColor),
+        )),
+    fontFamily: 'ElMessiri',
+    colorScheme: ColorScheme.dark(
+        primary: kDarkBackgroundColor,
+        secondary: kBackgroundColor,
+        surface: kDarkPrimaryColor,
+        onPrimary: kDarkAccentColor),
+  );
+}
+
+Color kLightBackgroundColor = const Color(0xffffffff);
+Color kBackgroundColor = const Color(0xFFFFFFFF);
+Color kLightPrimaryColor =
+    Colors.blueGrey.shade600; //const Color.fromARGB(255, 118, 101, 179);
+Color kLightSecondaryColor = const Color(0xff040415);
+Color kLightParticlesColor = const Color(0x44948282);
+const Color kLightTextColor = Colors.black;
+
+Color kDarkBackgroundColor = const Color(0xFF1A2127);
+Color kDarkPrimaryColor = const Color(0xFF1A2127);
+Color kDarkAccentColor = Colors.blueGrey.shade600;
+Color kDarkParticlesColor = const Color(0x441C2A3D);
+Color kDarkTextColor = Colors.white;

--- a/example/lib/widgets/payment.dart
+++ b/example/lib/widgets/payment.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:coffee_flutter/theme/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:moyasar/moyasar.dart';
 
@@ -37,9 +38,8 @@ class PaymentMethods extends StatelessWidget {
                 style: ButtonStyle(
                   minimumSize:
                       const WidgetStatePropertyAll<Size>(Size.fromHeight(55)),
-                  backgroundColor: const WidgetStatePropertyAll<Color>(
-                    Colors.white,
-                  ),
+                  backgroundColor:
+                      WidgetStatePropertyAll<Color>(kLightPrimaryColor),
                   shape: WidgetStateProperty.all<RoundedRectangleBorder>(
                     RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12.0),
@@ -56,10 +56,10 @@ class PaymentMethods extends StatelessWidget {
                                 onPaymentResult: onPaymentResult))),
                   );
                 },
-                child: const Text(
+                child: Text(
                   'Pay with STC Demo',
                   style: TextStyle(
-                    color: Colors.blue,
+                    color: kBackgroundColor,
                     fontWeight: FontWeight.bold,
                     fontSize: 16,
                   ),

--- a/lib/src/widgets/credit_card.dart
+++ b/lib/src/widgets/credit_card.dart
@@ -5,6 +5,7 @@ import 'package:moyasar/src/utils/card_utils.dart';
 import 'package:moyasar/src/utils/input_formatters.dart';
 import 'package:moyasar/src/widgets/network_icons.dart';
 import 'package:moyasar/src/widgets/three_d_s_webview.dart';
+import 'package:moyasar/theme/moyasar_theme.dart';
 
 /// The widget that shows the Credit Card form and manages the 3DS step.
 class CreditCard extends StatefulWidget {
@@ -26,6 +27,7 @@ class CreditCard extends StatefulWidget {
 }
 
 class _CreditCardState extends State<CreditCard> {
+
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
   final _cardData = CardFormModel();
@@ -172,6 +174,8 @@ class _CreditCardState extends State<CreditCard> {
 
   @override
   Widget build(BuildContext context) {
+  final theme = MoyasarTheme.of(context)?.data ?? Theme.of(context);
+
     return Form(
       autovalidateMode: _autoValidateMode,
       key: _formKey,

--- a/lib/src/widgets/credit_card.dart
+++ b/lib/src/widgets/credit_card.dart
@@ -27,7 +27,6 @@ class CreditCard extends StatefulWidget {
 }
 
 class _CreditCardState extends State<CreditCard> {
-
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
   final _cardData = CardFormModel();
@@ -174,225 +173,224 @@ class _CreditCardState extends State<CreditCard> {
 
   @override
   Widget build(BuildContext context) {
-  final theme = MoyasarTheme.of(context)?.data ?? Theme.of(context);
+    final theme = MoyasarTheme.of(context)?.data ?? Theme.of(context);
 
-    return Form(
-      autovalidateMode: _autoValidateMode,
-      key: _formKey,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(_nameError ?? widget.locale.nameOnCard,
-              style: TextStyle(
-                fontSize: 16,
-                color: _nameError != null ? Colors.red : Colors.black,
-              )),
-          SizedBox(
-            height: 8,
-          ),
-          Container(
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(12),
-              boxShadow: [
-                BoxShadow(
-                  color: Colors.black26,
-                  blurRadius: 4,
-                  offset: Offset(0, 2),
-                ),
-              ],
+    return Container(
+      padding: EdgeInsets.all(2.0),
+      child: Form(
+        autovalidateMode: _autoValidateMode,
+        key: _formKey,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(_nameError ?? widget.locale.nameOnCard,
+                style: TextStyle(
+                  fontSize: 16,
+                  color: _nameError != null
+                      ? Colors.red
+                      : theme.textTheme.bodyLarge?.color,
+                )),
+            SizedBox(
+              height: 8,
             ),
-            padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 0),
-            child: CardFormField(
-              inputDecoration: buildInputDecoration(
-                  hintText: widget.locale.nameOnCard,
-                  hideBorder: true,
-                  hintTextDirection: widget.textDirection),
-              keyboardType: TextInputType.text,
-              onChanged: _validateName,
-              onSaved: (value) => _cardData.name = value ?? '',
-              inputFormatters: [
-                FilteringTextInputFormatter.allow(RegExp('[a-zA-Z. ]')),
-              ],
-            ),
-          ),
-          SizedBox(
-            height: 30,
-          ),
-          Text(
-              _cardNumberError ??
-                  _expiryError ??
-                  _cvcError ??
-                  widget.locale.cardInformation,
-              style: TextStyle(
-                fontSize: 16,
-                color: (_cardNumberError != null ||
-                        _expiryError != null ||
-                        _cvcError != null)
-                    ? Colors.red
-                    : Colors.black,
-              )),
-          SizedBox(
-            height: 8,
-          ),
-          Container(
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(12),
-              boxShadow: [
-                BoxShadow(
-                  color: Colors.black26,
-                  blurRadius: 4,
-                  offset: Offset(0, 2),
-                ),
-              ],
-            ),
-            padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                CardFormField(
-                  inputDecoration: buildInputDecoration(
-                      hintText: widget.locale.cardNumber,
-                      hintTextDirection: widget.textDirection,
-                      hideBorder: true,
-                      addNetworkIcons: true),
-                  onChanged: _validateCardNumber,
-                  inputFormatters: [
-                    FilteringTextInputFormatter.digitsOnly,
-                    LengthLimitingTextInputFormatter(16),
-                    CardNumberInputFormatter(),
-                  ],
-                  onSaved: (value) =>
-                      _cardData.number = CardUtils.getCleanedNumber(value!),
-                ),
-                const Divider(height: 2),
-                Row(
-                  children: [
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          CardFormField(
-                            inputDecoration: buildInputDecoration(
-                              hintText: '${widget.locale.expiry} (MM / YY)',
-                              hintTextDirection: widget.textDirection,
-                              hideBorder: true,
-                            ),
-                            inputFormatters: [
-                              FilteringTextInputFormatter.digitsOnly,
-                              LengthLimitingTextInputFormatter(4),
-                              CardMonthInputFormatter(),
-                            ],
-                            onChanged: _validateExpiry,
-                            onSaved: (value) {
-                              List<String> expireDate = CardUtils.getExpiryDate(
-                                  value!.replaceAll('\u200E', ''));
-                              _cardData.month =
-                                  expireDate.first.replaceAll('\u200E', '');
-                              _cardData.year =
-                                  expireDate[1].replaceAll('\u200E', '');
-                            },
-                          ),
-                        ],
-                      ),
-                    ),
-                    SizedBox(
-                      height: 48,
-                      child: VerticalDivider(
-                        color: Colors.grey,
-                        thickness: 1,
-                        width: 2,
-                      ),
-                    ),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          CardFormField(
-                            inputDecoration: buildInputDecoration(
-                              hintText: widget.locale.cvc,
-                              hintTextDirection: widget.textDirection,
-                              hideBorder: true,
-                            ),
-                            inputFormatters: [
-                              FilteringTextInputFormatter.digitsOnly,
-                              LengthLimitingTextInputFormatter(4),
-                            ],
-                            onChanged: _validateCVC,
-                            onSaved: (value) => _cardData.cvc = value ?? '',
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-          SizedBox(
-            height: 8,
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8.0),
-            child: SizedBox(
-              child: ElevatedButton(
-                style: ButtonStyle(
-                  minimumSize:
-                      const WidgetStatePropertyAll<Size>(Size.fromHeight(55)),
-                  backgroundColor: WidgetStatePropertyAll<Color>(
-                    _isButtonEnabled ? blueColor : lightBlueColor,
-                  ),
-                  shape: WidgetStateProperty.all<RoundedRectangleBorder>(
-                    RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12.0),
-                    ),
-                  ),
-                ),
-                onPressed: _isButtonEnabled ? _saveForm : null,
-                child: _isSubmitting
-                    ? const CircularProgressIndicator(
-                        color: Colors.white,
-                        strokeWidth: 2,
-                      )
-                    : Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Spacer(),
-                          Text(
-                            '${widget.locale.pay} ',
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontWeight: FontWeight.bold,
-                              fontSize: 16,
-                            ),
-                            textDirection: widget.textDirection,
-                          ),
-                          SizedBox(
-                              width: 16,
-                              child: Image.asset(
-                                'assets/images/saudiriyal.png',
-                                color: Colors.white, // Tint color
-                                package: 'moyasar',
-                              )),
-                          const SizedBox(width: 4),
-                          Text(
-                            getAmount(widget.config.amount),
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontWeight: FontWeight.bold,
-                              fontSize: 16,
-                            ),
-                            textDirection: widget.textDirection,
-                          ),
-                          Spacer(),
-                        ],
-                      ),
+            Container(
+              decoration: BoxDecoration(
+                color: theme.colorScheme.onPrimary,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 0),
+              child: CardFormField(
+                inputDecoration: buildInputDecoration(
+                    theme: theme,
+                    hintText: widget.locale.nameOnCard,
+                    hideBorder: true,
+                    hintTextDirection: widget.textDirection),
+                keyboardType: TextInputType.text,
+                onChanged: _validateName,
+                onSaved: (value) => _cardData.name = value ?? '',
+                inputFormatters: [
+                  FilteringTextInputFormatter.allow(RegExp('[a-zA-Z. ]')),
+                ],
               ),
             ),
-          ),
-          SaveCardNotice(tokenizeCard: _tokenizeCard, locale: widget.locale),
-        ],
+            SizedBox(
+              height: 30,
+            ),
+            Text(
+                _cardNumberError ??
+                    _expiryError ??
+                    _cvcError ??
+                    widget.locale.cardInformation,
+                style: TextStyle(
+                  fontSize: 16,
+                  color: (_cardNumberError != null ||
+                          _expiryError != null ||
+                          _cvcError != null)
+                      ? Colors.red
+                      : theme.textTheme.bodyLarge?.color,
+                )),
+            SizedBox(
+              height: 8,
+            ),
+            Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  CardFormField(
+                    inputDecoration: buildInputDecoration(
+                        theme: theme,
+                        hintText: widget.locale.cardNumber,
+                        hintTextDirection: widget.textDirection,
+                        hideBorder: true,
+                        addNetworkIcons: true),
+                    onChanged: _validateCardNumber,
+                    inputFormatters: [
+                      FilteringTextInputFormatter.digitsOnly,
+                      LengthLimitingTextInputFormatter(16),
+                      CardNumberInputFormatter(),
+                    ],
+                    onSaved: (value) =>
+                        _cardData.number = CardUtils.getCleanedNumber(value!),
+                  ),
+                  // const Divider(height: 2),
+                  SizedBox(
+                    height: 8,
+                  ),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            CardFormField(
+                              inputDecoration: buildInputDecoration(
+                                theme: theme,
+                                hintText: '${widget.locale.expiry} (MM / YY)',
+                                hintTextDirection: widget.textDirection,
+                                hideBorder: true,
+                              ),
+                              inputFormatters: [
+                                FilteringTextInputFormatter.digitsOnly,
+                                LengthLimitingTextInputFormatter(4),
+                                CardMonthInputFormatter(),
+                              ],
+                              onChanged: _validateExpiry,
+                              onSaved: (value) {
+                                List<String> expireDate =
+                                    CardUtils.getExpiryDate(
+                                        value!.replaceAll('\u200E', ''));
+                                _cardData.month =
+                                    expireDate.first.replaceAll('\u200E', '');
+                                _cardData.year =
+                                    expireDate[1].replaceAll('\u200E', '');
+                              },
+                            ),
+                          ],
+                        ),
+                      ),
+                      SizedBox(
+                        width: 2,
+                      ),
+                      SizedBox(
+                        height: 48,
+                        child: VerticalDivider(
+                          color: theme.dividerColor,
+                          thickness: 1,
+                          width: 2,
+                        ),
+                      ),
+                      SizedBox(
+                        width: 2,
+                      ),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            CardFormField(
+                              inputDecoration: buildInputDecoration(
+                                theme: theme,
+                                hintText: widget.locale.cvc,
+                                hintTextDirection: widget.textDirection,
+                                hideBorder: true,
+                              ),
+                              inputFormatters: [
+                                FilteringTextInputFormatter.digitsOnly,
+                                LengthLimitingTextInputFormatter(4),
+                              ],
+                              onChanged: _validateCVC,
+                              onSaved: (value) => _cardData.cvc = value ?? '',
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(
+              height: 8,
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              child: SizedBox(
+                child: ElevatedButton(
+                  style: ButtonStyle(
+                    minimumSize:
+                        const WidgetStatePropertyAll<Size>(Size.fromHeight(55)),
+                    backgroundColor: WidgetStatePropertyAll<Color>(
+                      _isButtonEnabled
+                          ? theme.colorScheme.onPrimary
+                          : theme.colorScheme.onPrimary
+                        ..withOpacity(0.5),
+                    ),
+                    shape: WidgetStateProperty.all<RoundedRectangleBorder>(
+                      RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12.0),
+                      ),
+                    ),
+                  ),
+                  onPressed: _isButtonEnabled ? _saveForm : null,
+                  child: _isSubmitting
+                      ? const CircularProgressIndicator(
+                          color: Colors.white,
+                          strokeWidth: 2,
+                        )
+                      : Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Spacer(),
+                            Text(
+                              '${widget.locale.pay} ',
+                              style: theme.textTheme.labelLarge,
+                              textDirection: widget.textDirection,
+                            ),
+                            SizedBox(
+                                width: 16,
+                                child: Image.asset(
+                                  'assets/images/saudiriyal.png',
+                                  color: theme.colorScheme.secondary,
+                                  package: 'moyasar',
+                                )),
+                            const SizedBox(width: 4),
+                            Text(
+                              getAmount(widget.config.amount),
+                              style: theme.textTheme.labelLarge,
+                              textDirection: widget.textDirection,
+                            ),
+                            Spacer(),
+                          ],
+                        ),
+                ),
+              ),
+            ),
+            SaveCardNotice(tokenizeCard: _tokenizeCard, locale: widget.locale),
+          ],
+        ),
       ),
     );
   }
@@ -407,6 +405,7 @@ class SaveCardNotice extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = MoyasarTheme.of(context)?.data ?? Theme.of(context);
     return tokenizeCard
         ? Padding(
             padding: const EdgeInsets.all(8.0),
@@ -416,14 +415,14 @@ class SaveCardNotice extends StatelessWidget {
               children: [
                 Icon(
                   Icons.info,
-                  color: blueColor,
+                  color: getLightBlueColor(theme),
                 ),
                 const Padding(
                   padding: EdgeInsets.only(right: 5),
                 ),
                 Text(
                   locale.saveCardNotice,
-                  style: TextStyle(color: blueColor),
+                  style: TextStyle(color: getBlueColor(theme)),
                 ),
               ],
             ))
@@ -479,12 +478,15 @@ String getAmount(int amount) {
 InputDecoration buildInputDecoration(
     {required String hintText,
     required TextDirection hintTextDirection,
+    required ThemeData theme,
     bool addNetworkIcons = false,
     bool hideBorder = false}) {
   return InputDecoration(
       suffixIcon: addNetworkIcons ? const NetworkIcons() : null,
       hintText: hintText,
-      border: hideBorder ? InputBorder.none : defaultEnabledBorder,
+      hintStyle: TextStyle(color: Colors.grey),
+      border: getEnabledBorder(theme),
+      focusedBorder: getFocusedBorder(theme),
       hintTextDirection: hintTextDirection,
       contentPadding: const EdgeInsets.all(8.0));
 }
@@ -493,17 +495,27 @@ void closeKeyboard() => FocusManager.instance.primaryFocus?.unfocus();
 
 BorderRadius defaultBorderRadius = const BorderRadius.all(Radius.circular(8));
 
-OutlineInputBorder defaultEnabledBorder = OutlineInputBorder(
-    borderSide: BorderSide(color: Colors.grey[400]!),
-    borderRadius: defaultBorderRadius);
+OutlineInputBorder getEnabledBorder(ThemeData theme) {
+  return OutlineInputBorder(
+    borderSide: BorderSide(color: theme.dividerColor),
+    borderRadius: defaultBorderRadius,
+  );
+}
 
-OutlineInputBorder defaultFocusedBorder = OutlineInputBorder(
-    borderSide: BorderSide(color: Colors.grey[600]!),
-    borderRadius: defaultBorderRadius);
+OutlineInputBorder getFocusedBorder(ThemeData theme) {
+  return OutlineInputBorder(
+    borderSide: BorderSide(color: theme.colorScheme.primary),
+    borderRadius: defaultBorderRadius,
+  );
+}
 
-OutlineInputBorder defaultErrorBorder = OutlineInputBorder(
-    borderSide: const BorderSide(color: Colors.red),
-    borderRadius: defaultBorderRadius);
+OutlineInputBorder getErrorBorder(ThemeData theme) {
+  return OutlineInputBorder(
+    borderSide: BorderSide(color: theme.colorScheme.error),
+    borderRadius: defaultBorderRadius,
+  );
+}
 
-Color blueColor = Colors.blue[700]!;
-Color lightBlueColor = Colors.blue[100]!;
+Color getBlueColor(ThemeData theme) => theme.colorScheme.primary;
+Color getLightBlueColor(ThemeData theme) =>
+    theme.colorScheme.primary.withOpacity(0.2);

--- a/lib/src/widgets/stc_pay.dart
+++ b/lib/src/widgets/stc_pay.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:moyasar/moyasar.dart';
 import 'package:moyasar/src/models/sources/stc/stc_request_source.dart';
+import 'package:moyasar/theme/moyasar_theme.dart';
 
 import '../models/sources/stc/stc_response_source.dart';
 
@@ -246,6 +247,8 @@ class _STCPaymentFormState extends State<STCPaymentComponent> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = MoyasarTheme.of(context)?.data ?? Theme.of(context);
+
     return Scaffold(
       appBar: AppBar(),
       body: Padding(
@@ -262,12 +265,12 @@ class _STCPaymentFormState extends State<STCPaymentComponent> {
                   ? widget.locale.invalidPhoneNumber
                   : widget.locale.mobileNumber,
               style: TextStyle(
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
-                color: _controller.text.isNotEmpty && !_isValid
-                    ? Colors.red // error color
-                    : Colors.black, // normal color
-              ),
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: _controller.text.isNotEmpty && !_isValid
+                      ? Colors.red // error color
+                      : theme.textTheme.bodyLarge?.color // normal color
+                  ),
               textDirection: widget.textDirection,
             ),
 
@@ -323,11 +326,15 @@ class _STCPaymentFormState extends State<STCPaymentComponent> {
               width: double.infinity,
               child: ElevatedButton(
                 style: ButtonStyle(
+                  elevation: WidgetStatePropertyAll(4.0),
                   minimumSize: const WidgetStatePropertyAll<Size>(
                     Size.fromHeight(55),
                   ),
                   backgroundColor: WidgetStatePropertyAll<Color>(
-                    _isValid ? purpleColor : lightPurpleColor,
+                    _isValid
+                        ? theme.colorScheme.onPrimary
+                        : theme.colorScheme.onPrimary
+                      ..withOpacity(0.5),
                   ),
                 ),
                 onPressed: _isValid

--- a/lib/theme/moyasar_theme.dart
+++ b/lib/theme/moyasar_theme.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class MoyasarTheme extends InheritedWidget {
+  final ThemeData data;
+
+  const MoyasarTheme({super.key, required this.data, required super.child});
+
+  static MoyasarTheme? of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<MoyasarTheme>();
+  }
+
+  @override
+  bool updateShouldNotify(covariant MoyasarTheme oldWidget) {
+    return oldWidget.data != data;
+  }
+}


### PR DESCRIPTION
## MoyasarTheme
added a class MoyasarTheme that will be wrapping the PaymentMethods widget and takes data parametar ( them data of the app , that can be send as needed dark or light).
##
```MoyasarTheme(
                  data: AppTheme.darkTheme,
                  child: PaymentMethods(
                    paymentConfig: paymentConfig,
                    onPaymentResult: onPaymentResult,
                  ),
                ),```
<img width="324" height="670" alt="dark1" src="https://github.com/user-attachments/assets/e6612b47-f75f-477b-8ce9-d678cfd313d2" />
<img width="326" height="667" alt="dark2" src="https://github.com/user-attachments/assets/1b8c2944-08dc-4bd6-9ee1-ce6a3eb410c5" />
<img width="325" height="673" alt="light1" src="https://github.com/user-attachments/assets/ed0b57c0-7591-4c07-bb9e-26c96452b5c4" />
<img width="323" height="695" alt="light2" src="https://github.com/user-attachments/assets/6ce7264c-0562-403c-b712-98d2133d89d6" />
