### PR TITLE
using inputDecorationTheme.fillColor

### DIFF
--- a/lib/src/widgets/credit_card.dart
+++ b/lib/src/widgets/credit_card.dart
@@ -208,6 +208,7 @@ class _CreditCardState extends State<CreditCard> {
 
   @override
   Widget build(BuildContext context) {
+    final fieldColor = Theme.of(context).inputDecorationTheme.fillColor;
     return Form(
       autovalidateMode: _autoValidateMode,
       key: _formKey,
@@ -229,7 +230,7 @@ class _CreditCardState extends State<CreditCard> {
           ),
           Container(
             decoration: BoxDecoration(
-              color: Colors.white,
+              color: fieldColor,
               borderRadius: BorderRadius.circular(6),
               boxShadow: [
                 BoxShadow(
@@ -279,7 +280,7 @@ class _CreditCardState extends State<CreditCard> {
           ),
           Container(
             decoration: BoxDecoration(
-              color: Colors.white,
+              color: fieldColor,
               borderRadius: BorderRadius.circular(6),
               boxShadow: [
                 BoxShadow(


### PR DESCRIPTION
using inputDecorationTheme.fillColor
for CardFormField Container
to fix dark - light colors bug
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-11-26 at 21 45 53" src="https://github.com/user-attachments/assets/9bfeea8e-6406-4904-b52d-0db7ece3f10a" />
