### PR TITLE
Add CreditCardTheme and harden the 3DS webview

### DIFF
--- a/lib/moyasar.dart
+++ b/lib/moyasar.dart
@@ -13,6 +13,7 @@ export 'src/models/payment_split.dart' show PaymentSplit;
 export 'src/models/apple_pay_config.dart' show ApplePayConfig;
 export 'src/models/samsung_pay_config.dart' show SamsungPayConfig;
 export 'src/models/credit_card_config.dart' show CreditCardConfig;
+export 'src/models/credit_card_theme.dart' show CreditCardTheme;
 export 'src/models/payment_request.dart' show PaymentRequest;
 export 'src/models/payment_response.dart' show PaymentResponse, PaymentStatus;
 

--- a/lib/src/models/credit_card_theme.dart
+++ b/lib/src/models/credit_card_theme.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+
+import '../utils/moyasar_text_styles.dart';
+
+/// Visual customization for the [CreditCard] widget.
+///
+/// Every value is optional and defaults to the SDK's built-in look, so
+/// omitting the theme keeps the previous appearance unchanged. Pass a theme to
+/// blend the form into the host app — most importantly to support a dark mode,
+/// which the built-in light-only defaults cannot express:
+///
+/// ```dart
+/// CreditCard(
+///   config: config,
+///   onPaymentResult: onPaymentResult,
+///   theme: CreditCardTheme(
+///     backgroundColor: myTheme.background,
+///     fieldColor: myTheme.surface,
+///     labelColor: myTheme.headingText,
+///     buttonColor: myTheme.primary,
+///     noticeColor: myTheme.descriptionText,
+///     fontFamily: 'MyAppFont',
+///   ),
+/// )
+/// ```
+@immutable
+class CreditCardTheme {
+  const CreditCardTheme({
+    this.backgroundColor,
+    this.fieldColor = Colors.white,
+    this.fieldShadowColor = Colors.black26,
+    this.labelColor = Colors.black,
+    this.inputTextColor,
+    this.hintColor = const Color(0xFF9E9E9E),
+    this.errorColor = Colors.red,
+    this.buttonColor = defaultAccentColor,
+    this.disabledButtonColor,
+    this.buttonTextColor = Colors.white,
+    this.noticeColor = defaultAccentColor,
+    this.fontFamily = MoyasarStyles.fontFamily,
+  });
+
+  /// The SDK's default accent, used for the pay button and the save-card
+  /// notice when no override is supplied.
+  static const Color defaultAccentColor = Color(0xFF768DFF);
+
+  /// Painted behind the whole form. When null nothing is painted and the
+  /// surrounding widget's background shows through.
+  final Color? backgroundColor;
+
+  /// Fill color of the boxes wrapping the input fields.
+  final Color fieldColor;
+
+  /// Drop-shadow color of those boxes.
+  final Color fieldShadowColor;
+
+  /// Color of the field labels ("Name on card", "Card information").
+  final Color labelColor;
+
+  /// Color of the text the user types. Defaults to [labelColor].
+  final Color? inputTextColor;
+
+  /// Color of the placeholder text inside the fields.
+  final Color hintColor;
+
+  /// Color labels turn when their field fails validation.
+  final Color errorColor;
+
+  /// Background of the pay button while it is enabled.
+  final Color buttonColor;
+
+  /// Background of the pay button while it is disabled. Defaults to
+  /// [buttonColor] at 30% opacity.
+  final Color? disabledButtonColor;
+
+  /// Color of the pay button's label, amount and progress indicator.
+  final Color buttonTextColor;
+
+  /// Color of the save-card notice icon and text.
+  final Color noticeColor;
+
+  /// Font family applied across the form. Defaults to the font bundled with
+  /// the SDK; set it to use the host app's font instead.
+  final String fontFamily;
+
+  Color get resolvedInputTextColor => inputTextColor ?? labelColor;
+
+  Color get resolvedDisabledButtonColor =>
+      disabledButtonColor ?? buttonColor.withValues(alpha: 0.3);
+
+  /// Color for a label that is showing [error] when non-null.
+  Color labelColorFor(Object? error) =>
+      error != null ? errorColor : labelColor;
+
+  CreditCardTheme copyWith({
+    Color? backgroundColor,
+    Color? fieldColor,
+    Color? fieldShadowColor,
+    Color? labelColor,
+    Color? inputTextColor,
+    Color? hintColor,
+    Color? errorColor,
+    Color? buttonColor,
+    Color? disabledButtonColor,
+    Color? buttonTextColor,
+    Color? noticeColor,
+    String? fontFamily,
+  }) {
+    return CreditCardTheme(
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      fieldColor: fieldColor ?? this.fieldColor,
+      fieldShadowColor: fieldShadowColor ?? this.fieldShadowColor,
+      labelColor: labelColor ?? this.labelColor,
+      inputTextColor: inputTextColor ?? this.inputTextColor,
+      hintColor: hintColor ?? this.hintColor,
+      errorColor: errorColor ?? this.errorColor,
+      buttonColor: buttonColor ?? this.buttonColor,
+      disabledButtonColor: disabledButtonColor ?? this.disabledButtonColor,
+      buttonTextColor: buttonTextColor ?? this.buttonTextColor,
+      noticeColor: noticeColor ?? this.noticeColor,
+      fontFamily: fontFamily ?? this.fontFamily,
+    );
+  }
+}

--- a/lib/src/widgets/apple_pay.dart
+++ b/lib/src/widgets/apple_pay.dart
@@ -11,6 +11,8 @@ class ApplePay extends StatefulWidget {
       required this.config,
       required this.onPaymentResult,
       this.buttonType = ApplePayButtonType.inStore,
+      this.onPressed,
+      this.onBeforePayment,
       this.buttonStyle = ApplePayButtonStyle.black})
       : assert(config.applePay != null,
             "Please add applePayConfig when instantiating the paymentConfig.");
@@ -18,6 +20,20 @@ class ApplePay extends StatefulWidget {
   final PaymentConfig config;
   final Function onPaymentResult;
   final ApplePayButtonType buttonType;
+
+  /// Called when the button is tapped, before the Apple Pay sheet is shown.
+  /// Useful for validating the screen or showing a loading state.
+  final VoidCallback? onPressed;
+
+  /// Called after Apple Pay authorizes the payment and a token is obtained,
+  /// but *before* the charge is sent to Moyasar.
+  ///
+  /// Return `false` to abort: nothing is charged and [onPaymentResult] is not
+  /// called. Use it for work that must succeed before taking money — creating
+  /// an order server-side, for example — so a failure there cannot leave the
+  /// customer charged without one.
+  final Future<bool> Function()? onBeforePayment;
+
   final ApplePayButtonStyle buttonStyle;
   final MethodChannel channel =
       const MethodChannel('flutter.moyasar.com/apple_pay');
@@ -62,6 +78,15 @@ class _ApplePayState extends State<ApplePay> {
     if (((token ?? '') == '')) {
       widget.onPaymentResult(UnprocessableTokenError());
       return;
+    }
+
+    // Give the host app a chance to do work that must succeed before the card
+    // is charged. If it reports failure, stop here so nothing is taken.
+    if (widget.onBeforePayment != null) {
+      final shouldContinue = await widget.onBeforePayment!();
+      if (!shouldContinue) {
+        return;
+      }
     }
 
     final source = ApplePayPaymentRequestSource(token,
@@ -119,6 +144,7 @@ class _ApplePayState extends State<ApplePay> {
             ],
             type: widget.buttonType,
             style: widget.buttonStyle,
+            onPressed: widget.onPressed,
             onPaymentResult: onApplePayResult,
             width: MediaQuery.of(context).size.width,
             height: 40,

--- a/lib/src/widgets/credit_card.dart
+++ b/lib/src/widgets/credit_card.dart
@@ -4,7 +4,6 @@ import 'package:moyasar/moyasar.dart';
 import 'package:moyasar/src/utils/card_utils.dart';
 import 'package:moyasar/src/utils/input_formatters.dart';
 import 'package:moyasar/src/utils/card_network_utils.dart';
-import 'package:moyasar/src/utils/moyasar_text_styles.dart';
 import 'package:moyasar/src/widgets/network_icons.dart';
 import 'package:moyasar/src/widgets/three_d_s_webview.dart';
 
@@ -14,7 +13,8 @@ class CreditCard extends StatefulWidget {
       {super.key,
       required this.config,
       required this.onPaymentResult,
-      this.locale = const Localization.en()})
+      this.locale = const Localization.en(),
+      this.theme = const CreditCardTheme()})
       : textDirection =
             locale.languageCode == 'ar' ? TextDirection.rtl : TextDirection.ltr;
 
@@ -22,6 +22,10 @@ class CreditCard extends StatefulWidget {
   final PaymentConfig config;
   final Localization locale;
   final TextDirection textDirection;
+
+  /// Colors and font used to render the form. Defaults to the SDK's built-in
+  /// light appearance.
+  final CreditCardTheme theme;
 
   @override
   State<CreditCard> createState() => _CreditCardState();
@@ -219,7 +223,8 @@ class _CreditCardState extends State<CreditCard> {
 
   @override
   Widget build(BuildContext context) {
-    return Form(
+    final theme = widget.theme;
+    final form = Form(
       autovalidateMode: _autoValidateMode,
       key: _formKey,
       child: Column(
@@ -230,21 +235,21 @@ class _CreditCardState extends State<CreditCard> {
                   ? TextAlign.right
                   : TextAlign.left,
               style: TextStyle(
-                fontFamily: MoyasarStyles.fontFamily,
+                fontFamily: theme.fontFamily,
                 fontWeight: FontWeight.w500,
                 fontSize: 16,
-                color: _nameError != null ? Colors.red : Colors.black,
+                color: theme.labelColorFor(_nameError),
               )),
           SizedBox(
             height: 8,
           ),
           Container(
             decoration: BoxDecoration(
-              color: Colors.white,
+              color: theme.fieldColor,
               borderRadius: BorderRadius.circular(6),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black26,
+                  color: theme.fieldShadowColor,
                   blurRadius: 4,
                   offset: Offset(0, 2),
                 ),
@@ -252,9 +257,11 @@ class _CreditCardState extends State<CreditCard> {
             ),
             padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 0),
             child: CardFormField(
+              theme: theme,
               inputDecoration: buildInputDecoration(
                   hintText: widget.locale.nameOnCard,
                   hideBorder: true,
+                  theme: theme,
                   hintTextDirection: widget.textDirection),
               keyboardType: TextInputType.text,
               onChanged: _validateName,
@@ -276,25 +283,22 @@ class _CreditCardState extends State<CreditCard> {
                   ? TextAlign.right
                   : TextAlign.left,
               style: TextStyle(
-                fontFamily: MoyasarStyles.fontFamily,
+                fontFamily: theme.fontFamily,
                 fontWeight: FontWeight.w500,
                 fontSize: 16,
-                color: (_cardNumberError != null ||
-                        _expiryError != null ||
-                        _cvcError != null)
-                    ? Colors.red
-                    : Colors.black,
+                color: theme.labelColorFor(
+                    _cardNumberError ?? _expiryError ?? _cvcError),
               )),
           SizedBox(
             height: 8,
           ),
           Container(
             decoration: BoxDecoration(
-              color: Colors.white,
+              color: theme.fieldColor,
               borderRadius: BorderRadius.circular(6),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black26,
+                  color: theme.fieldShadowColor,
                   blurRadius: 4,
                   offset: Offset(0, 2),
                 ),
@@ -307,10 +311,12 @@ class _CreditCardState extends State<CreditCard> {
                   : CrossAxisAlignment.start,
               children: [
                 CardFormField(
+                  theme: theme,
                   inputDecoration: buildInputDecoration(
                       hintText: widget.locale.cardNumber,
                       hintTextDirection: widget.textDirection,
                       hideBorder: true,
+                      theme: theme,
                       addNetworkIcons: true,
                       config: widget.config,
                       detectedNetwork: _detectedNetwork,
@@ -336,10 +342,12 @@ class _CreditCardState extends State<CreditCard> {
                                 : CrossAxisAlignment.start,
                         children: [
                           CardFormField(
+                            theme: theme,
                             inputDecoration: buildInputDecoration(
                               hintText: '${widget.locale.expiry} (MM / YY)',
                               hintTextDirection: widget.textDirection,
                               hideBorder: true,
+                              theme: theme,
                             ),
                             inputFormatters: [
                               FilteringTextInputFormatter.digitsOnly,
@@ -375,10 +383,12 @@ class _CreditCardState extends State<CreditCard> {
                                 : CrossAxisAlignment.start,
                         children: [
                           CardFormField(
+                            theme: theme,
                             inputDecoration: buildInputDecoration(
                               hintText: widget.locale.cvc,
                               hintTextDirection: widget.textDirection,
                               hideBorder: true,
+                              theme: theme,
                             ),
                             inputFormatters: [
                               FilteringTextInputFormatter.digitsOnly,
@@ -406,7 +416,9 @@ class _CreditCardState extends State<CreditCard> {
                   minimumSize:
                       const WidgetStatePropertyAll<Size>(Size.fromHeight(52)),
                   backgroundColor: WidgetStatePropertyAll<Color>(
-                    _isButtonEnabled ? blueColor : lightBlueColor,
+                    _isButtonEnabled
+                        ? theme.buttonColor
+                        : theme.resolvedDisabledButtonColor,
                   ),
                   shape: WidgetStateProperty.all<RoundedRectangleBorder>(
                     RoundedRectangleBorder(
@@ -416,8 +428,8 @@ class _CreditCardState extends State<CreditCard> {
                 ),
                 onPressed: _isButtonEnabled ? _saveForm : null,
                 child: _isSubmitting
-                    ? const CircularProgressIndicator(
-                        color: Colors.white,
+                    ? CircularProgressIndicator(
+                        color: theme.buttonTextColor,
                         strokeWidth: 2,
                       )
                     : Directionality(
@@ -430,8 +442,8 @@ class _CreditCardState extends State<CreditCard> {
                             Text(
                               '${widget.locale.pay} ',
                               style: TextStyle(
-                                fontFamily: MoyasarStyles.fontFamily,
-                                color: Colors.white,
+                                fontFamily: theme.fontFamily,
+                                color: theme.buttonTextColor,
                                 fontWeight: FontWeight.w500,
                                 fontSize: 16,
                               ),
@@ -441,15 +453,15 @@ class _CreditCardState extends State<CreditCard> {
                                 width: 16,
                                 child: Image.asset(
                                   'assets/images/saudiriyal.png',
-                                  color: Colors.white,
+                                  color: theme.buttonTextColor,
                                   package: 'moyasar',
                                 )),
                             const SizedBox(width: 4),
                             Text(
                               getAmount(widget.config.amount),
                               style: TextStyle(
-                                fontFamily: MoyasarStyles.fontFamily,
-                                color: Colors.white,
+                                fontFamily: theme.fontFamily,
+                                color: theme.buttonTextColor,
                                 fontWeight: FontWeight.w500,
                                 fontSize: 16,
                               ),
@@ -472,10 +484,16 @@ class _CreditCardState extends State<CreditCard> {
             tokenizeCard: _tokenizeCard,
             locale: widget.locale,
             textDirection: widget.textDirection,
+            theme: theme,
           ),
         ],
       ),
     );
+
+    final background = theme.backgroundColor;
+    return background == null
+        ? form
+        : ColoredBox(color: background, child: form);
   }
 }
 
@@ -485,11 +503,13 @@ class SaveCardNotice extends StatelessWidget {
     required this.tokenizeCard,
     required this.locale,
     required this.textDirection,
+    this.theme = const CreditCardTheme(),
   });
 
   final bool tokenizeCard;
   final Localization locale;
   final TextDirection textDirection;
+  final CreditCardTheme theme;
 
   @override
   Widget build(BuildContext context) {
@@ -507,15 +527,15 @@ class SaveCardNotice extends StatelessWidget {
                 children: [
                   Icon(
                     Icons.info,
-                    color: blueColor,
+                    color: theme.noticeColor,
                   ),
                   SizedBox(width: 5),
                   Flexible(
                     child: Text(
                       locale.saveCardNotice,
                       style: TextStyle(
-                          fontFamily: MoyasarStyles.fontFamily,
-                          color: blueColor,
+                          fontFamily: theme.fontFamily,
+                          color: theme.noticeColor,
                           fontWeight: FontWeight.w500),
                       textDirection: textDirection,
                       textAlign: isRTL ? TextAlign.right : TextAlign.left,
@@ -536,6 +556,7 @@ class CardFormField extends StatelessWidget {
   final TextInputAction textInputAction;
   final List<TextInputFormatter>? inputFormatters;
   final InputDecoration? inputDecoration;
+  final CreditCardTheme theme;
 
   const CardFormField(
       {super.key,
@@ -545,14 +566,17 @@ class CardFormField extends StatelessWidget {
       this.inputDecoration,
       this.keyboardType = TextInputType.number,
       this.textInputAction = TextInputAction.next,
-      this.inputFormatters});
+      this.inputFormatters,
+      this.theme = const CreditCardTheme()});
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 0),
       child: TextFormField(
-        style: TextStyle(fontFamily: MoyasarStyles.fontFamily),
+        style: TextStyle(
+            fontFamily: theme.fontFamily,
+            color: theme.resolvedInputTextColor),
         keyboardType: keyboardType,
         textInputAction: textInputAction,
         decoration: inputDecoration,
@@ -586,7 +610,8 @@ InputDecoration buildInputDecoration(
     bool hideBorder = false,
     PaymentConfig? config,
     CardNetwork? detectedNetwork,
-    bool unsupportedNetwork = false}) {
+    bool unsupportedNetwork = false,
+    CreditCardTheme theme = const CreditCardTheme()}) {
   Widget? iconWidget;
   if (addNetworkIcons && config != null) {
     if (detectedNetwork != null) {
@@ -628,8 +653,8 @@ InputDecoration buildInputDecoration(
     suffixIcon: isRTL ? null : iconWidget,
     prefixIcon: isRTL ? iconWidget : null,
     hintText: hintText,
-    hintStyle: TextStyle(
-        fontFamily: MoyasarStyles.fontFamily, color: Color(0xFF9E9E9E)),
+    hintStyle:
+        TextStyle(fontFamily: theme.fontFamily, color: theme.hintColor),
     border: hideBorder ? InputBorder.none : defaultEnabledBorder,
     isDense: true,
     contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),

--- a/lib/src/widgets/three_d_s_webview.dart
+++ b/lib/src/widgets/three_d_s_webview.dart
@@ -27,22 +27,36 @@ class _ThreeDSWebViewState extends State<ThreeDSWebView> {
   void initWebViewController() {
     final controller = WebViewController()
       ..loadRequest(Uri.parse(widget.transactionUrl))
+      // JavaScript must stay enabled — bank 3DS challenge pages require it.
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      ..setNavigationDelegate(NavigationDelegate(onPageFinished: (pageUrl) {
-        final redirectedTo = Uri.parse(pageUrl);
+      ..setNavigationDelegate(NavigationDelegate(
+        // Allow-list schemes: bank/gateway redirects and the callback URL are
+        // http(s) only. Block every other scheme (javascript:, data:, file:,
+        // intent:, ...) so a compromised or malicious 3DS page cannot escape
+        // the payment flow.
+        onNavigationRequest: (NavigationRequest request) {
+          final scheme = Uri.tryParse(request.url)?.scheme;
+          if (scheme != 'https' && scheme != 'http') {
+            return NavigationDecision.prevent;
+          }
+          return NavigationDecision.navigate;
+        },
+        onPageFinished: (pageUrl) {
+          final redirectedTo = Uri.parse(pageUrl);
 
-        final bool hasReachedFinalRedirection =
-            redirectedTo.host == widget.callbackUri.host;
+          final bool hasReachedFinalRedirection =
+              redirectedTo.host == widget.callbackUri.host;
 
-        if (hasReachedFinalRedirection) {
-          final queryParams = redirectedTo.queryParameters;
+          if (hasReachedFinalRedirection) {
+            final queryParams = redirectedTo.queryParameters;
 
-          String status = queryParams['status'] ?? '';
-          String message = queryParams['message'] ?? '';
+            String status = queryParams['status'] ?? '';
+            String message = queryParams['message'] ?? '';
 
-          widget.on3dsDone(status, message);
-        }
-      }));
+            widget.on3dsDone(status, message);
+          }
+        },
+      ));
 
     _controller = controller;
   }


### PR DESCRIPTION
The credit card form hardcoded a light-only palette, so host apps could not match it to their own design (dark mode in particular). Introduce an optional CreditCardTheme covering the background, field boxes, labels, input/hint text, the pay button, the save-card notice and the font family. Every value defaults to the previous appearance, so omitting `theme` is a no-op.

Also restrict the 3DS webview to http(s) navigation. Bank redirects and the callback URL are always http(s), so allow-listing those blocks javascript:, data:, file: and intent: URLs from being followed inside the payment flow.


## Description

#### Ticket #:

<!-- Any extra details that might be helpful for reviewers. -->

## How to test

<!-- Brief instruction on how this change can be tested. -->

## Screenshots
<!-- Add screenshots if applicable -->

## Deployment Notes
<!-- Any deployment notes that need to be made. -->
